### PR TITLE
Add margin-top to footer, remove title margin-top

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -3,6 +3,7 @@ a {
 }
 
 footer {
+  margin-top: 20px;
   padding-top: 30px;
   padding-bottom: 30px;
   background-color: #eee;
@@ -11,6 +12,10 @@ footer {
 .message img {
   border: 1px solid #444;
   display: inline-block;
+}
+
+.message h3 {
+  margin-top: 0;
 }
 
 .message {


### PR DESCRIPTION
Gap between content and footer is way too small, especially on the login screen. Ugh! 

H3 margin change affects only single message pages, where it lifts content up a bit.
