### PR TITLE
Always use HTTPS to load OpenStreetMap tiles

### DIFF
--- a/views/map.html
+++ b/views/map.html
@@ -9,7 +9,7 @@
 
 var map = L.map('map').setView([60.1708, 24.9375], 13);
 
-var OpenStreetMap = L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+var OpenStreetMap = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
 });
 map.addLayer(OpenStreetMap);


### PR DESCRIPTION
This would work both in HTTP and HTTPS contexts.